### PR TITLE
Set default value of MESATEE_CFG_DIR in service.sh

### DIFF
--- a/service.sh
+++ b/service.sh
@@ -5,6 +5,14 @@ if [ -z "${MESATEE_BIN}" ]; then
     echo "env var MESATEE_BIN is not set, use ${MESATEE_BIN}"
 fi
 
+if [ -z "${MESATEE_CFG_DIR}" ]; then
+    SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+    MESATEE_CFG_DIR=$SCRIPT_DIR
+    echo "env var MESATEE_CFG_DIR is not set, use ${MESATEE_CFG_DIR}"
+fi
+
+export MESATEE_CFG_DIR
+
 get_stdout_file() {
     echo -n "/tmp/$1.log"
 }


### PR DESCRIPTION
## Description

Set default value of `MESATEE_CFG_DIR` in service.sh. `environment.deprecated` is no longer needed.

## Type of change (select applied and DELETE the others)

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

CI: https://ci.mesalock-linux.org/mssun/incubator-mesatee/10

## Checklist (check ALL before submitting PR, even not applicable)

- [x] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
