### PR TITLE
Use environment variable to configure IAS SPID/KEY

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -150,6 +150,8 @@ steps:
   - cd build && cmake -DRUSTFLAGS="-D warnings" -DSGX_MODE=SW .. && make VERBOSE=1 -j2
 - name: sgx-test
   image: mesalocklinux/build-mesatee:0.1.5
+  environment:
+    SGX_MODE: SW
   commands:
   - . /root/.cargo/env
   - cd build && make sgx-test
@@ -181,6 +183,8 @@ steps:
   - cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DRUSTFLAGS="-D warnings" -DSGX_MODE=SW .. && make VERBOSE=1 -j2
 - name: sgx-test
   image: mesalocklinux/build-mesatee:0.1.5
+  environment:
+    SGX_MODE: SW
   commands:
   - . /root/.cargo/env
   - cd build && make sgx-test

--- a/.drone.yml
+++ b/.drone.yml
@@ -150,10 +150,6 @@ steps:
   - cd build && cmake -DRUSTFLAGS="-D warnings" -DSGX_MODE=SW .. && make VERBOSE=1 -j2
 - name: sgx-test
   image: mesalocklinux/build-mesatee:0.1.5
-  environment:
-    IAS_SPID:
-      from_secret: V5_SPID
-  privileged: true
   commands:
   - . /root/.cargo/env
   - cd build && make sgx-test
@@ -185,10 +181,6 @@ steps:
   - cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DRUSTFLAGS="-D warnings" -DSGX_MODE=SW .. && make VERBOSE=1 -j2
 - name: sgx-test
   image: mesalocklinux/build-mesatee:0.1.5
-  environment:
-    IAS_SPID:
-      from_secret: V5_SPID
-  privileged: true
   commands:
   - . /root/.cargo/env
   - cd build && make sgx-test

--- a/.drone.yml
+++ b/.drone.yml
@@ -24,9 +24,9 @@ steps:
   image: mesalocklinux/build-mesatee:0.1.5
   privileged: true
   environment:
-    V5_KEY:
+    IAS_KEY:
       from_secret: V5_KEY
-    V5_SPID:
+    IAS_SPID:
       from_secret: V5_SPID
   volumes:
   - name: isgx

--- a/.drone.yml
+++ b/.drone.yml
@@ -9,11 +9,6 @@ steps:
   - . /root/.cargo/env
   - mkdir -p build
   - cd build && cmake ..
-  environment:
-    IAS_KEY:
-      from_secret: V5_KEY
-    IAS_SPID:
-      from_secret: V5_SPID
 - name: check
   image: mesalocklinux/build-mesatee:0.1.5
   commands:
@@ -28,6 +23,11 @@ steps:
 - name: sgx-test
   image: mesalocklinux/build-mesatee:0.1.5
   privileged: true
+  environment:
+    IAS_KEY:
+      from_secret: V5_KEY
+    IAS_SPID:
+      from_secret: V5_SPID
   volumes:
   - name: isgx
     path: /dev/isgx
@@ -87,11 +87,6 @@ steps:
   - . /root/.cargo/env
   - mkdir -p build
   - cd build && cmake -DCMAKE_BUILD_TYPE=Debug ..
-  environment:
-    IAS_KEY:
-      from_secret: V5_KEY
-    IAS_SPID:
-      from_secret: V5_SPID
 - name: check
   image: mesalocklinux/build-mesatee:0.1.5
   commands:
@@ -106,6 +101,11 @@ steps:
 - name: sgx-test
   image: mesalocklinux/build-mesatee:0.1.5
   privileged: true
+  environment:
+    IAS_KEY:
+      from_secret: V5_KEY
+    IAS_SPID:
+      from_secret: V5_SPID
   volumes:
   - name: isgx
     path: /dev/isgx
@@ -138,10 +138,6 @@ steps:
   - . /root/.cargo/env
   - mkdir -p build
   - cd build && cmake ..
-  environment:
-    IAS_SPID:
-      from_secret: V5_SPID
-- name: check
   image: mesalocklinux/build-mesatee:0.1.5
   commands:
   - . /root/.cargo/env
@@ -154,6 +150,10 @@ steps:
 - name: sgx-test
   image: mesalocklinux/build-mesatee:0.1.5
   privileged: true
+  environment:
+    IAS_SPID:
+      from_secret: V5_SPID
+- name: check
   commands:
   - . /root/.cargo/env
   - cd build && make sgx-test
@@ -173,9 +173,6 @@ steps:
   - . /root/.cargo/env
   - mkdir -p build
   - cd build && cmake ..
-  environment:
-    IAS_SPID:
-      from_secret: V5_SPID
 - name: check
   image: mesalocklinux/build-mesatee:0.1.5
   commands:
@@ -189,6 +186,9 @@ steps:
 - name: sgx-test
   image: mesalocklinux/build-mesatee:0.1.5
   privileged: true
+  environment:
+    IAS_SPID:
+      from_secret: V5_SPID
   commands:
   - . /root/.cargo/env
   - cd build && make sgx-test

--- a/.drone.yml
+++ b/.drone.yml
@@ -186,7 +186,7 @@ steps:
 - name: sgx-test
   image: mesalocklinux/build-mesatee:0.1.5
   environment:
-    V5_SPID:
+    IAS_SPID:
       from_secret: V5_SPID
   privileged: true
   commands:

--- a/.drone.yml
+++ b/.drone.yml
@@ -92,9 +92,9 @@ steps:
   - mkdir -p build
   - cd build && cmake -DCMAKE_BUILD_TYPE=Debug ..
   environment:
-    V5_KEY:
+    IAS_KEY:
       from_secret: V5_KEY
-    V5_SPID:
+    IAS_SPID:
       from_secret: V5_SPID
 - name: check
   image: mesalocklinux/build-mesatee:0.1.5

--- a/.drone.yml
+++ b/.drone.yml
@@ -6,15 +6,13 @@ steps:
   image: mesalocklinux/build-mesatee:0.1.5
   commands:
   - mkdir -p bin
-  - echo $V5_SPID > bin/ias_spid.txt
-  - echo $V5_KEY > bin/ias_key.txt
   - . /root/.cargo/env
   - mkdir -p build
   - cd build && cmake ..
   environment:
-    V5_KEY:
+    IAS_KEY:
       from_secret: V5_KEY
-    V5_SPID:
+    IAS_SPID:
       from_secret: V5_SPID
 - name: check
   image: mesalocklinux/build-mesatee:0.1.5
@@ -86,8 +84,6 @@ steps:
   image: mesalocklinux/build-mesatee:0.1.5
   commands:
   - mkdir -p bin
-  - echo $V5_SPID > bin/ias_spid.txt
-  - echo $V5_KEY > bin/ias_key.txt
   - . /root/.cargo/env
   - mkdir -p build
   - cd build && cmake -DCMAKE_BUILD_TYPE=Debug ..
@@ -143,7 +139,7 @@ steps:
   - mkdir -p build
   - cd build && cmake ..
   environment:
-    V5_SPID:
+    IAS_SPID:
       from_secret: V5_SPID
 - name: check
   image: mesalocklinux/build-mesatee:0.1.5
@@ -178,7 +174,7 @@ steps:
   - mkdir -p build
   - cd build && cmake ..
   environment:
-    V5_SPID:
+    IAS_SPID:
       from_secret: V5_SPID
 - name: check
   image: mesalocklinux/build-mesatee:0.1.5

--- a/.drone.yml
+++ b/.drone.yml
@@ -150,11 +150,24 @@ steps:
   - cd build && cmake -DRUSTFLAGS="-D warnings" -DSGX_MODE=SW .. && make VERBOSE=1 -j2
 - name: sgx-test
   image: mesalocklinux/build-mesatee:0.1.5
-  environment:
-    SGX_MODE: SW
   commands:
   - . /root/.cargo/env
   - cd build && make sgx-test
+  privileged: true
+  volumes:
+  - name: isgx
+    path: /dev/isgx
+  - name: aesmd
+    path: /var/run/aesmd/aesm.socket
+
+volumes:
+- name: isgx
+  host:
+    path: /dev/isgx
+- name: aesmd
+  host:
+    path: /var/run/aesmd/aesm.socket
+
 
 node:
   instance: mesatee-sgx
@@ -183,11 +196,23 @@ steps:
   - cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DRUSTFLAGS="-D warnings" -DSGX_MODE=SW .. && make VERBOSE=1 -j2
 - name: sgx-test
   image: mesalocklinux/build-mesatee:0.1.5
-  environment:
-    SGX_MODE: SW
   commands:
   - . /root/.cargo/env
   - cd build && make sgx-test
+  privileged: true
+  volumes:
+  - name: isgx
+    path: /dev/isgx
+  - name: aesmd
+    path: /var/run/aesmd/aesm.socket
+
+volumes:
+- name: isgx
+  host:
+    path: /dev/isgx
+- name: aesmd
+  host:
+    path: /var/run/aesmd/aesm.socket
 
 node:
   instance: mesatee-sgx

--- a/.drone.yml
+++ b/.drone.yml
@@ -24,9 +24,9 @@ steps:
   image: mesalocklinux/build-mesatee:0.1.5
   privileged: true
   environment:
-    IAS_KEY:
+    V5_KEY:
       from_secret: V5_KEY
-    IAS_SPID:
+    V5_SPID:
       from_secret: V5_SPID
   volumes:
   - name: isgx
@@ -100,12 +100,12 @@ steps:
   - cd build && make VERBOSE=1 -j2
 - name: sgx-test
   image: mesalocklinux/build-mesatee:0.1.5
-  privileged: true
   environment:
     IAS_KEY:
       from_secret: V5_KEY
     IAS_SPID:
       from_secret: V5_SPID
+  privileged: true
   volumes:
   - name: isgx
     path: /dev/isgx
@@ -138,6 +138,7 @@ steps:
   - . /root/.cargo/env
   - mkdir -p build
   - cd build && cmake ..
+- name: check
   image: mesalocklinux/build-mesatee:0.1.5
   commands:
   - . /root/.cargo/env
@@ -149,11 +150,10 @@ steps:
   - cd build && cmake -DRUSTFLAGS="-D warnings" -DSGX_MODE=SW .. && make VERBOSE=1 -j2
 - name: sgx-test
   image: mesalocklinux/build-mesatee:0.1.5
-  privileged: true
   environment:
     IAS_SPID:
       from_secret: V5_SPID
-- name: check
+  privileged: true
   commands:
   - . /root/.cargo/env
   - cd build && make sgx-test
@@ -185,10 +185,10 @@ steps:
   - cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DRUSTFLAGS="-D warnings" -DSGX_MODE=SW .. && make VERBOSE=1 -j2
 - name: sgx-test
   image: mesalocklinux/build-mesatee:0.1.5
-  privileged: true
   environment:
-    IAS_SPID:
+    V5_SPID:
       from_secret: V5_SPID
+  privileged: true
   commands:
   - . /root/.cargo/env
   - cd build && make sgx-test

--- a/cmake/scripts/sgx_test.sh
+++ b/cmake/scripts/sgx_test.sh
@@ -8,9 +8,8 @@ fi
 
 source ${SGX_SDK}/environment
 if [ "${SGX_MODE}" = "HW" ]; then
-	if [ ! -f ${MESATEE_BIN_DIR}/ias_spid.txt ] || [ ! -f ${MESATEE_BIN_DIR}/ias_key.txt ] ; then
-        echo "Please follow \"How to Run (SGX)\" in README to obtain \
-ias_spid.txt and ias_key.txt, and put in the bin";
+	if [ -z ${IAS_SPID} ] || [ -z ${IAS_KEY} ] ; then
+        echo "SGX launch check failed: Env var for IAS SPID or IAS KEY does NOT exist. Please follow \"How to Run (SGX)\" in README to obtain, and specify the value in environment variables and put the names of environment variables in config.toml. The default variables are IAS_SPID and IAS_KEY."
         exit 1;
     fi
 fi

--- a/config.toml
+++ b/config.toml
@@ -55,8 +55,8 @@ acs  = { listen_ip = "0.0.0.0", connect_ip = "127.0.0.1", port = 5077 }
 # connect to Intel® Attestation Service (IAS).
 # This is a required section.
 [ias_client_config]
-spid = { path = "bin/ias_spid.txt" }
-key = { path = "bin/ias_key.txt" }
+spid = { env = "IAS_SPID" }
+key = { env = "IAS_KEY" }
 
 
 # This section configures the auditors.

--- a/config.toml
+++ b/config.toml
@@ -51,8 +51,8 @@ kms  = { listen_ip = "0.0.0.0", connect_ip = "127.0.0.1", port = 6016 }
 acs  = { listen_ip = "0.0.0.0", connect_ip = "127.0.0.1", port = 5077 }
 
 
-# This section configures the location of certificate/private key used to
-# connect to Intel® Attestation Service (IAS).
+# This section configures the IAS API key/spid which are used to connect to
+# Intel® Attestation Service (IAS).
 # This is a required section.
 [ias_client_config]
 spid = { env = "IAS_SPID" }

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,13 +1,13 @@
 # FAQs in Build and Run
 
-## Why did I see ``SGX launch check failed: ias_spid.txt or ias_key.txt does NOT exist``?
+## Why did I see ``SGX launch check failed: Env var for IAS SPID or IAS KEY does NOT exist.``
 
 Because the Intel Attestation Service (IAS) requires mutual authentication in
 TLS communications. So if you have followed [build
 prerequisite](how_to_build.md#prerequisite) document for Intel Attestation
 Service (IAS) registration, you should be able to obtain the SPID, Primary Key,
-and Secondary Key . Please configure their paths in the ``ias_client_config``
-section of [config.toml](../config.toml) accordingly. 
+and Secondary Key . Please set them as environment variables, e.g. `export IAS_KEY=...`, and then configure them in the ``ias_client_config`` section of
+[config.toml](../config.toml) accordingly.
 
 MesaTEE uses the most recent [Intel IAS API version 5](https://api.trustedservices.intel.com/documents/sgx-attestation-api-spec.pdf).
 It no longer requires certificate from IAS client. Instead, it requires a **Subscription Key** for access. Please read the [manual](https://api.trustedservices.intel.com/documents/sgx-attestation-api-spec.pdf) and [build prerequisite](how_to_build.md#prerequisite) for details.

--- a/docs/how_to_run.md
+++ b/docs/how_to_run.md
@@ -13,9 +13,15 @@ The ``api_endpoints`` and ``internal_endpoints``  of
 services. Please configure them accordingly.
 
 Then, please set SPID and key (either primary or secondary) from Intel Trusted
-Service API portal by ``cat YOUR_SPID > ./bin/ias_spid.txt && cat YOUR_KEY > ./bin/ias_key.txt``.
-Note that the default paths for `ias_spid.txt` and `ias_key.txt` is under the `./bin` directory,
-but can be configured in the `config.toml` file.
+Service API portal by ``export IAS_KEY=YOUR_SPID && export IAS_SPID=YOUR_KEY``.
+Next, please edit [config.toml](../config.toml) to tell MesaTEE where to find
+IAS API key and SPID:
+
+```toml
+[ias_client_config]
+spid = { env = "IAS_SPID" }
+key = { env = "IAS_KEY" }
+```
 
 Afterwards, you can launch MesaTEE services as background daemons by running:
 ``./service.sh {start|stop|restart}``

--- a/mesatee_config/src/runtime_config.rs
+++ b/mesatee_config/src/runtime_config.rs
@@ -230,8 +230,8 @@ lazy_static! {
         //let ias_client_key_path = Path::new(&mesatee_cfg_dir)
         //    .to_path_buf()
         //    .join(&MESATEE_CONFIG_TOML.ias_client_config["key"].env);
-        let ias_client_spid_envvar = env::var(&MESATEE_CONFIG_TOML.ias_client_config["spid"].env).unwrap_or("".into());
-        let ias_client_key_envvar = env::var(&MESATEE_CONFIG_TOML.ias_client_config["key"].env).unwrap_or("".into());
+        let ias_client_spid_envvar = env::var(&MESATEE_CONFIG_TOML.ias_client_config["spid"].env).unwrap_or_else("".into());
+        let ias_client_key_envvar = env::var(&MESATEE_CONFIG_TOML.ias_client_config["key"].env).unwrap_or_else("".into());
 
         MesateeConfig {
             tms_external_listen_addr: MESATEE_CONFIG_TOML.api_endpoints["tms"].listen_ip,

--- a/mesatee_config/src/runtime_config.rs
+++ b/mesatee_config/src/runtime_config.rs
@@ -142,7 +142,8 @@ fn get_mesatee_cfg_dir() -> String {
     match env::var(&MESATEE_CFG_DIR_ENV) {
         Ok(p) => p,
         Err(_) => {
-            #[cfg(feature = "mesalock_sgx")] use std::println;
+            #[cfg(feature = "mesalock_sgx")]
+            use std::println;
             println!("Missing environment variable MESATEE_CFG_DIR. Using \".\"");
             ".".to_string()
         }

--- a/mesatee_config/src/runtime_config.rs
+++ b/mesatee_config/src/runtime_config.rs
@@ -223,15 +223,8 @@ lazy_static! {
             .to_path_buf()
             .join(&MESATEE_CONFIG_TOML.audited_enclave_config["signature_c"].path);
 
-        //let ias_client_spid_path = Path::new(&mesatee_cfg_dir)
-        //    .to_path_buf()
-        //    .join(&MESATEE_CONFIG_TOML.ias_client_config["spid"].env);
-
-        //let ias_client_key_path = Path::new(&mesatee_cfg_dir)
-        //    .to_path_buf()
-        //    .join(&MESATEE_CONFIG_TOML.ias_client_config["key"].env);
-        let ias_client_spid_envvar = env::var(&MESATEE_CONFIG_TOML.ias_client_config["spid"].env).unwrap_or_else("".into());
-        let ias_client_key_envvar = env::var(&MESATEE_CONFIG_TOML.ias_client_config["key"].env).unwrap_or_else("".into());
+        let ias_client_spid_envvar = env::var(&MESATEE_CONFIG_TOML.ias_client_config["spid"].env).unwrap_or_else(|_| "".into());
+        let ias_client_key_envvar = env::var(&MESATEE_CONFIG_TOML.ias_client_config["key"].env).unwrap_or_else(|_| "".into());
 
         MesateeConfig {
             tms_external_listen_addr: MESATEE_CONFIG_TOML.api_endpoints["tms"].listen_ip,

--- a/mesatee_config/src/runtime_config.rs
+++ b/mesatee_config/src/runtime_config.rs
@@ -230,8 +230,8 @@ lazy_static! {
         //let ias_client_key_path = Path::new(&mesatee_cfg_dir)
         //    .to_path_buf()
         //    .join(&MESATEE_CONFIG_TOML.ias_client_config["key"].env);
-        let ias_client_spid_envvar = env::var(&MESATEE_CONFIG_TOML.ias_client_config["spid"].env).unwrap();
-        let ias_client_key_envvar = env::var(&MESATEE_CONFIG_TOML.ias_client_config["key"].env).unwrap();
+        let ias_client_spid_envvar = env::var(&MESATEE_CONFIG_TOML.ias_client_config["spid"].env).unwrap_or("".into());
+        let ias_client_key_envvar = env::var(&MESATEE_CONFIG_TOML.ias_client_config["key"].env).unwrap_or("".into());
 
         MesateeConfig {
             tms_external_listen_addr: MESATEE_CONFIG_TOML.api_endpoints["tms"].listen_ip,

--- a/mesatee_core/src/utils.rs
+++ b/mesatee_core/src/utils.rs
@@ -20,8 +20,8 @@ use mesatee_config::MESATEE_CONFIG;
 pub fn sgx_launch_check() -> Result<()> {
     // check the existence of env var specified in config.toml
     if !cfg!(sgx_sim)
-        && (!std::env::var(&MESATEE_CONFIG.ias_client_spid_envvar).is_err()
-            || !std::env::var(&MESATEE_CONFIG.ias_client_key_envvar).is_err())
+        && (std::env::var(&MESATEE_CONFIG.ias_client_spid_envvar).is_ok()
+            || std::env::var(&MESATEE_CONFIG.ias_client_key_envvar).is_ok())
     {
         error!("SGX launch check failed: Env var for IAS SPID or IAS KEY does NOT exist. Please follow \"How to Run (SGX)\" in README to obtain, and specify the value in environment variables and put the names of environment variables in config.toml.");
         return Err(ErrorKind::IASClientKeyCertError.into());

--- a/mesatee_core/src/utils.rs
+++ b/mesatee_core/src/utils.rs
@@ -14,18 +14,16 @@
 
 use crate::error::{ErrorKind, Result};
 use mesatee_config::MESATEE_CONFIG;
-use std::path::Path;
 
 // check prerequisites to make the launching process smoother
 // the launching may still fail even after passing the check
 pub fn sgx_launch_check() -> Result<()> {
-    // check the existence of ias_spid.txt and ias_key.txt
+    // check the existence of env var specified in config.toml
     if !cfg!(sgx_sim)
-        && (!Path::new(&MESATEE_CONFIG.ias_client_spid_path).is_file()
-            || !Path::new(&MESATEE_CONFIG.ias_client_key_path).is_file())
+        && (!std::env::var(&MESATEE_CONFIG.ias_client_spid_envvar).is_err()
+            || !std::env::var(&MESATEE_CONFIG.ias_client_key_envvar).is_err())
     {
-        error!("SGX launch check failed: {} or {} does NOT exist. Please follow \"How to Run (SGX)\" in README to obtain.",
-        "ias_spid.txt", "ias_key.txt");
+        error!("SGX launch check failed: Env var for IAS SPID or IAS KEY does NOT exist. Please follow \"How to Run (SGX)\" in README to obtain, and specify the value in environment variables and put the names of environment variables in config.toml.");
         return Err(ErrorKind::IASClientKeyCertError.into());
     }
     Ok(())


### PR DESCRIPTION
## Description

Current design of IAS configuration is not friendly to k8s. #80 discussed it. In this PR, I updated mesatee_config to acquire IAS key/spid from environment variables specified in `config.toml`. Updated CI scripts accordingly.

This is a **breaking change**. The previous configuration (ias_key.txt + ias_spid.txt) is deprecated.

Fixes #80 

## Type of change (select applied and DELETE the others)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just sync with upstream third-party crates

## How Has This Been Tested?

CI script updated and passed. [proof](http://ci.mesalock-linux.org/dingelish/incubator-mesatee/18)

## Checklist (check ALL before submitting PR, even not applicable)

- [x] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
