### PR TITLE
Storage dir can be set by env var (MESATEE_STORAGE_DIR)

### DIFF
--- a/docs/how_to_build.md
+++ b/docs/how_to_build.md
@@ -93,6 +93,7 @@ help set the variables. Below is the description for the environment variables:
 * ``MESATEE_PROJECT_ROOT``: MesaTEE project root directory
 * ``MESATEE_CFG_DIR``: directory containing the runtime config
 * ``MESATEE_BUILD_CFG_DIR``: directory containing the compile time config
+* `MESATEE_SOTRAGE_DIR`: directory for TDFS data storage, default is `/tmp`
 * ``MESATEE_AUDITORS_DIR``: directory containing auditors' public keys and endorsement to TEE enclaves (digital signatures)
 * ``MESATEE_TEST_MODE``: whether executing in testing mode
 * ``RUST_LOG``: logging levels

--- a/mesatee_services/tdfs/sgx_trusted_lib/src/data_store.rs
+++ b/mesatee_services/tdfs/sgx_trusted_lib/src/data_store.rs
@@ -52,7 +52,7 @@ lazy_static! {
 
 impl FileMeta {
     pub fn get_access_path(&self) -> String {
-        let storage_dir = env::var("MESATEE_STORAGE_DIR").unwrap_or("/tmp".into());
+        let storage_dir = env::var("MESATEE_STORAGE_DIR").unwrap_or_else(|_| "/tmp".into());
         Path::new(&storage_dir)
             .join(&self.storage_path)
             .to_string_lossy()

--- a/mesatee_services/tdfs/sgx_trusted_lib/src/data_store.rs
+++ b/mesatee_services/tdfs/sgx_trusted_lib/src/data_store.rs
@@ -20,7 +20,8 @@ use lazy_static::lazy_static;
 use mesatee_core::db::Memdb;
 use mesatee_core::{Error, ErrorKind, Result};
 use std::collections::HashSet;
-use std::format;
+use std::env;
+use std::path::Path;
 use std::sync::SgxMutex;
 
 #[derive(Clone)]
@@ -51,7 +52,11 @@ lazy_static! {
 
 impl FileMeta {
     pub fn get_access_path(&self) -> String {
-        format!("/tmp/{}", self.storage_path)
+        let storage_dir = env::var("MESATEE_STORAGE_DIR").unwrap_or("/tmp".into());
+        Path::new(&storage_dir)
+            .join(&self.storage_path)
+            .to_string_lossy()
+            .to_string()
     }
 
     pub fn check_permission(&self, user_id: &str) -> bool {

--- a/tests/integration_test/test_data/test.toml
+++ b/tests/integration_test/test_data/test.toml
@@ -63,7 +63,7 @@ payload = """
 {"type":"Get","file_id":"fake_file_record","user_id":"fake_file_owner","user_token":"token"}
 """
 expected = """
-{"type":"Get","file_info":{"user_id":"fake_file_owner","file_name":"fake_file","sha256":"aaa","file_size":100,"access_path":"/tmp/fake_file","task_id":null,"collaborator_list":[],"key_config":{"key":"QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE=","nonce":"QUFBQUFBQUFBQUFB","ad":"QUFBQUE="}}}
+{"type":"Get","file_info":{"user_id":"fake_file_owner","file_name":"fake_file","sha256":"aaa","file_size":100,"access_path":"/*/fake_file","task_id":null,"collaborator_list":[],"key_config":{"key":"QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE=","nonce":"QUFBQUFBQUFBQUFB","ad":"QUFBQUE="}}}
 """
 
 [[step]]


### PR DESCRIPTION
## Description

Introduce a new env var: `MESATEE_STORAGE_DIR`. This will be used to setup path for TDFS.

## Type of change (select applied and DELETE the others)

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
CI

## Checklist (check ALL before submitting PR, even not applicable)

- [x] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
