### PR TITLE
Fix coverage testing error because of wrong path of llvm-gcov.

### DIFF
--- a/cmake/scripts/gen_cov.sh
+++ b/cmake/scripts/gen_cov.sh
@@ -8,7 +8,7 @@ done
 
 
 LCOV=lcov
-LCOVOPT="--gcov-tool ${MESATEE_PROJECT_ROOT}/build/llvm-gcov"
+LCOVOPT="--gcov-tool ${MESATEE_PROJECT_ROOT}/toolchain_deps/llvm-gcov"
 GENHTML=genhtml
 
 cd ${MESATEE_PROJECT_ROOT}


### PR DESCRIPTION
## Description

Fix coverage testing error because of wrong path of llvm-gcov in gen_cov.sh .

## Type of change (select applied and DELETE the others)

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Yes
## Checklist (check ALL before submitting PR, even not applicable)

- [x] Fork the repo and create your branch from `master`.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
