### PR TITLE
Exclude generated files for rustfmt

### DIFF
--- a/cmake/UtilTargets.cmake
+++ b/cmake/UtilTargets.cmake
@@ -7,7 +7,7 @@ add_custom_target(format
 	COMMAND RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN} find ${MESATEE_PROJECT_ROOT}
 		-path ${MESATEE_PROJECT_ROOT}/third_party -prune -o
 		-path ${MESATEE_PROJECT_ROOT}/.git -prune -o
-	 	-path *porst_generated -prune -o
+	 	-path *prost_generated -prune -o
         -name "*.rs" -exec rustfmt {} +
     COMMENT "Formating every .rs file"
     DEPENDS prep

--- a/cmake/UtilTargets.cmake
+++ b/cmake/UtilTargets.cmake
@@ -7,6 +7,7 @@ add_custom_target(format
 	COMMAND RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN} find ${MESATEE_PROJECT_ROOT}
 		-path ${MESATEE_PROJECT_ROOT}/third_party -prune -o
 		-path ${MESATEE_PROJECT_ROOT}/.git -prune -o
+	 	-path *porst_generated -prune -o
         -name "*.rs" -exec rustfmt {} +
     COMMENT "Formating every .rs file"
     DEPENDS prep
@@ -17,6 +18,7 @@ add_custom_target(check
 	COMMAND RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN} find ${MESATEE_PROJECT_ROOT}
         -path ${MESATEE_PROJECT_ROOT}/third_party -prune -o
         -path ${MESATEE_PROJECT_ROOT}/.git -prune -o
+        -path *prost_generated -prune -o
         -name "*.rs" -exec rustfmt --check {} +
     COMMENT "Checking the format of every .rs file"
     DEPENDS prep

--- a/mesatee_services/kms/proto/build.rs
+++ b/mesatee_services/kms/proto/build.rs
@@ -20,7 +20,7 @@ include!("../../common/prost_build_generator.rs");
 
 #[cfg(not(feature = "mesalock_sgx"))]
 fn main() {
-    let src=PathBuf::from("src");
+    let src = PathBuf::from("src");
     let output = src.join("prost_generated");
     if !output.exists() {
         std::fs::create_dir(&output).expect("failed to create prost_generated dir");

--- a/mesatee_services/kms/proto/build.rs
+++ b/mesatee_services/kms/proto/build.rs
@@ -20,7 +20,7 @@ include!("../../common/prost_build_generator.rs");
 
 #[cfg(not(feature = "mesalock_sgx"))]
 fn main() {
-    let src = PathBuf::from("src");
+    let src=PathBuf::from("src");
     let output = src.join("prost_generated");
     if !output.exists() {
         std::fs::create_dir(&output).expect("failed to create prost_generated dir");

--- a/mesatee_services/kms/proto/src/prost_generated/kms_proto.rs
+++ b/mesatee_services/kms/proto/src/prost_generated/kms_proto.rs
@@ -1,67 +1,75 @@
-#[derive(Clone, PartialEq, ::prost::Message, serde_derive::Serialize, serde_derive::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct CreateKeyRequest {
-    #[prost(enumeration = "EncType", required, tag = "1")]
+    #[prost(enumeration="EncType", required, tag="1")]
     pub enc_type: i32,
 }
-#[derive(Clone, PartialEq, ::prost::Message, serde_derive::Serialize, serde_derive::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct AeadConfig {
-    #[prost(bytes, required, tag = "1")]
+    #[prost(bytes, required, tag="1")]
     #[serde(with = "crate::base64_coder")]
     pub key: std::vec::Vec<u8>,
-    #[prost(bytes, required, tag = "2")]
+    #[prost(bytes, required, tag="2")]
     #[serde(with = "crate::base64_coder")]
     pub nonce: std::vec::Vec<u8>,
-    #[prost(bytes, required, tag = "3")]
+    #[prost(bytes, required, tag="3")]
     #[serde(with = "crate::base64_coder")]
     pub ad: std::vec::Vec<u8>,
 }
-#[derive(Clone, PartialEq, ::prost::Message, serde_derive::Serialize, serde_derive::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct ProtectedFsConfig {
-    #[prost(bytes, required, tag = "1")]
+    #[prost(bytes, required, tag="1")]
     #[serde(with = "crate::base64_coder")]
     pub key: std::vec::Vec<u8>,
 }
-#[derive(Clone, PartialEq, ::prost::Message, serde_derive::Serialize, serde_derive::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct KeyConfig {
-    #[prost(oneof = "key_config::Config", tags = "1, 2")]
+    #[prost(oneof="key_config::Config", tags="1, 2")]
     pub config: ::std::option::Option<key_config::Config>,
 }
 pub mod key_config {
-    #[derive(
-        Clone, PartialEq, ::prost::Oneof, serde_derive::Serialize, serde_derive::Deserialize,
-    )]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
     pub enum Config {
-        #[prost(message, tag = "1")]
+        #[prost(message, tag="1")]
         Aead(super::AeadConfig),
-        #[prost(message, tag = "2")]
+        #[prost(message, tag="2")]
         ProtectedFs(super::ProtectedFsConfig),
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message, serde_derive::Serialize, serde_derive::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct CreateKeyResponse {
-    #[prost(string, required, tag = "1")]
+    #[prost(string, required, tag="1")]
     pub key_id: std::string::String,
-    #[prost(message, required, tag = "2")]
+    #[prost(message, required, tag="2")]
     pub config: KeyConfig,
 }
-#[derive(Clone, PartialEq, ::prost::Message, serde_derive::Serialize, serde_derive::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct GetKeyRequest {
-    #[prost(string, required, tag = "1")]
+    #[prost(string, required, tag="1")]
     pub key_id: std::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message, serde_derive::Serialize, serde_derive::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct GetKeyResponse {
-    #[prost(message, required, tag = "1")]
+    #[prost(message, required, tag="1")]
     pub config: KeyConfig,
 }
-#[derive(Clone, PartialEq, ::prost::Message, serde_derive::Serialize, serde_derive::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct DeleteKeyRequest {
-    #[prost(string, required, tag = "1")]
+    #[prost(string, required, tag="1")]
     pub key_id: std::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message, serde_derive::Serialize, serde_derive::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct DeleteKeyResponse {
-    #[prost(message, required, tag = "1")]
+    #[prost(message, required, tag="1")]
     pub config: KeyConfig,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -72,8 +80,7 @@ pub enum EncType {
     ProtectedFs = 1,
 }
 #[derive(Clone, serde_derive::Serialize, serde_derive::Deserialize, Debug)]
-#[serde(tag = "type")]
-pub enum KMSRequest {
+#[serde(tag = "type")]pub enum KMSRequest {
     GetKey(GetKeyRequest),
     DelKey(DeleteKeyRequest),
     CreateKey(CreateKeyRequest),
@@ -91,10 +98,7 @@ pub trait KMSService {
     fn create_key(req: CreateKeyRequest) -> mesatee_core::Result<CreateKeyResponse>;
     fn dispatch(&self, req: KMSRequest) -> mesatee_core::Result<KMSResponse> {
         match req {
-            KMSRequest::GetKey(req) => Self::get_key(req).map(KMSResponse::GetKey),
-            KMSRequest::DelKey(req) => Self::del_key(req).map(KMSResponse::DelKey),
-            KMSRequest::CreateKey(req) => Self::create_key(req).map(KMSResponse::CreateKey),
-        }
+            KMSRequest::GetKey(req) => Self::get_key(req).map(KMSResponse::GetKey),            KMSRequest::DelKey(req) => Self::del_key(req).map(KMSResponse::DelKey),            KMSRequest::CreateKey(req) => Self::create_key(req).map(KMSResponse::CreateKey),        }
     }
 }
 pub struct KMSClient {
@@ -106,10 +110,7 @@ impl KMSClient {
         let addr = target.addr;
         let channel = match target.desc {
             mesatee_core::config::OutboundDesc::Sgx(enclave_addr) => {
-                mesatee_core::rpc::channel::SgxTrustedChannel::<KMSRequest, KMSResponse>::new(
-                    addr,
-                    enclave_addr,
-                )?
+                mesatee_core::rpc::channel::SgxTrustedChannel::<KMSRequest, KMSResponse>::new(addr, enclave_addr)?
             }
         };
         Ok(KMSClient { channel })
@@ -121,9 +122,7 @@ impl KMSClient {
         let resp = self.channel.invoke(req)?;
         match resp {
             KMSResponse::GetKey(resp) => Ok(resp),
-            _ => Err(mesatee_core::Error::from(
-                mesatee_core::ErrorKind::RPCResponseError,
-            )),
+            _ => Err(mesatee_core::Error::from(mesatee_core::ErrorKind::RPCResponseError)),
         }
     }
 
@@ -132,9 +131,7 @@ impl KMSClient {
         let resp = self.channel.invoke(req)?;
         match resp {
             KMSResponse::DelKey(resp) => Ok(resp),
-            _ => Err(mesatee_core::Error::from(
-                mesatee_core::ErrorKind::RPCResponseError,
-            )),
+            _ => Err(mesatee_core::Error::from(mesatee_core::ErrorKind::RPCResponseError)),
         }
     }
 
@@ -143,9 +140,7 @@ impl KMSClient {
         let resp = self.channel.invoke(req)?;
         match resp {
             KMSResponse::CreateKey(resp) => Ok(resp),
-            _ => Err(mesatee_core::Error::from(
-                mesatee_core::ErrorKind::RPCResponseError,
-            )),
+            _ => Err(mesatee_core::Error::from(mesatee_core::ErrorKind::RPCResponseError)),
         }
     }
 }


### PR DESCRIPTION
## Description

Exclude generated files for ```make format``` and ```make check```. All the files  under prost_generated will be excluded. 

Fixes #116 

## Type of change (select applied and DELETE the others)

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Generated kms_proto will not be formated. Passed CI: http://ci.mesalock-linux.org/litongxin1991/incubator-mesatee/33/5/4

Other files will be formatted or checked. See this failed CI result: http://ci.mesalock-linux.org/litongxin1991/incubator-mesatee/32/1/3 

## Checklist (check ALL before submitting PR, even not applicable)

- [X] Fork the repo and create your branch from `master`.
- [X] If you've added code that should be tested, add tests.
- [X] If you've changed APIs, update the documentation.
- [X] Ensure the tests pass (see CI results).
- [ X Make sure your code lints/format.
