### PR TITLE
use relative path in TDFS Server and RPC

### DIFF
--- a/mesatee_services/tdfs/external/client/src/tdfs_client.rs
+++ b/mesatee_services/tdfs/external/client/src/tdfs_client.rs
@@ -92,7 +92,7 @@ impl TDFSClient {
         let file_size = data.len() as u32;
         let resp = self.request_create_file(file_name, &sha256, file_size)?;
         let file_id = resp.file_id;
-        let access_path = resp.access_path;
+        let access_path = file_util::get_local_access_path(&resp.access_path);
         let key_config = resp.key_config;
         let encrypted_data =
             file_util::encrypt_data(data, &key_config.key, &key_config.nonce, &key_config.ad)?;
@@ -106,8 +106,8 @@ impl TDFSClient {
         let resp = self.request_get_file(file_id)?;
         let file_info = resp.file_info;
         let key_config = &file_info.key_config;
-        let access_path = &file_info.access_path;
-        let ciphertxt = fs::read(access_path)
+        let access_path = file_util::get_local_access_path(&file_info.access_path);
+        let ciphertxt = fs::read(&access_path)
             .map_err(|_| mesatee_core::Error::from(mesatee_core::ErrorKind::IoError))?;
 
         let plaintxt = file_util::decrypt_data(

--- a/mesatee_services/tdfs/internal/client/src/file_util.rs
+++ b/mesatee_services/tdfs/internal/client/src/file_util.rs
@@ -22,7 +22,9 @@ use std::prelude::v1::*;
 use mesatee_core::{Error, ErrorKind, Result};
 use ring::aead::{self, Aad, BoundKey, Nonce, UnboundKey};
 use ring::digest;
+use std::env;
 use std::fmt::Write;
+use std::path::{Path, PathBuf};
 
 struct OneNonceSequence(Option<aead::Nonce>);
 
@@ -95,4 +97,9 @@ pub fn cal_hash(data: &[u8]) -> Result<String> {
         write!(&mut digest_hex, "{:02x}", byte).map_err(|_| Error::from(ErrorKind::Unknown))?;
     }
     Ok(digest_hex)
+}
+
+pub fn get_local_access_path(relative_path: &str) -> PathBuf {
+    let storage_dir = env::var("MESATEE_STORAGE_DIR").unwrap_or_else(|_| "/tmp".into());
+    Path::new(&storage_dir).join(relative_path)
 }

--- a/mesatee_services/tdfs/internal/client/src/tdfs_client.rs
+++ b/mesatee_services/tdfs/internal/client/src/tdfs_client.rs
@@ -102,7 +102,7 @@ impl TDFSClient {
             allow_policy,
         )?;
         let file_id = resp.file_id;
-        let access_path = resp.access_path;
+        let access_path = file_util::get_local_access_path(&resp.access_path);
         let key_config = resp.key_config;
         let encrypted_data =
             file_util::encrypt_data(data, &key_config.key, &key_config.nonce, &key_config.ad)?;
@@ -151,7 +151,7 @@ impl TDFSClient {
             kms_proto::KeyConfig::Aead(config) => kms_proto::proto::AeadConfig::from(config),
             kms_proto::KeyConfig::ProtectedFs(_config) => unimplemented!(), // ProtectedFS is not used by TDFS yet. Config of ProtectedFs will not be generated neither.
         };
-        let access_path = &file_info.access_path;
+        let access_path = file_util::get_local_access_path(&file_info.access_path);
         let mut f = fs::File::open(access_path)?;
         let capacity: usize = file_info.file_size.try_into().unwrap_or(1024 * 1024) + 1024;
         let mut ciphertxt: Vec<u8> = Vec::with_capacity(capacity);

--- a/mesatee_services/tdfs/sgx_trusted_lib/src/data_store.rs
+++ b/mesatee_services/tdfs/sgx_trusted_lib/src/data_store.rs
@@ -23,8 +23,6 @@ use lazy_static::lazy_static;
 use mesatee_core::db::Memdb;
 use mesatee_core::{Error, ErrorKind, Result};
 use std::collections::HashSet;
-use std::env;
-use std::path::Path;
 use std::sync::SgxMutex;
 
 #[derive(Clone)]
@@ -55,11 +53,8 @@ lazy_static! {
 
 impl FileMeta {
     pub fn get_access_path(&self) -> String {
-        let storage_dir = env::var("MESATEE_STORAGE_DIR").unwrap_or_else(|_| "/tmp".into());
-        Path::new(&storage_dir)
-            .join(&self.storage_path)
-            .to_string_lossy()
-            .to_string()
+        // TDFS client will use the "MESATEE_STORAGE_DIR" to construct a local path
+        self.storage_path.to_owned()
     }
 
     pub fn check_permission(&self, user_id: &str) -> bool {

--- a/tests/integration_test/test_data/test.toml
+++ b/tests/integration_test/test_data/test.toml
@@ -63,7 +63,7 @@ payload = """
 {"type":"Get","file_id":"fake_file_record","user_id":"fake_file_owner","user_token":"token"}
 """
 expected = """
-{"type":"Get","file_info":{"user_id":"fake_file_owner","file_name":"fake_file","sha256":"aaa","file_size":100,"access_path":"/*/fake_file","task_id":null,"collaborator_list":[],"key_config":{"key":"QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE=","nonce":"QUFBQUFBQUFBQUFB","ad":"QUFBQUE="}}}
+{"type":"Get","file_info":{"user_id":"fake_file_owner","file_name":"fake_file","sha256":"aaa","file_size":100,"access_path":"fake_file","task_id":null,"collaborator_list":[],"key_config":{"key":"QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE=","nonce":"QUFBQUFBQUFBQUFB","ad":"QUFBQUE="}}}
 """
 
 [[step]]


### PR DESCRIPTION
## Description

Use relative path in TDFS Server and RPC. TDFS client will construct an absolute path with environment variable ``` MESATEE_STORAGE_DIR```.  So different services/clients can configure and use different storage directory. 

Fixes #91 

## Type of change (select applied and DELETE the others)

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Passed CI: http://ci.mesalock-linux.org/litongxin1991/incubator-mesatee/38/1/4
Passed ```make sgx-test``` locally with environment variable
```
MESATEE_STORAGE_DIR=/tmp/target_dir make sgx-test
```
No files generated in ```/tmp/```, files are generated in ```/tmp/target_dir```

## Checklist (check ALL before submitting PR, even not applicable)

- [X] Fork the repo and create your branch from `master`.
- [X] If you've added code that should be tested, add tests.
- [X] If you've changed APIs, update the documentation.
- [X] Ensure the tests pass (see CI results).
- [X] Make sure your code lints/format.
