### PR TITLE
Support more operations for ProtectedFile.

### DIFF
--- a/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs.h
+++ b/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs.h
@@ -262,14 +262,37 @@ int32_t SGXAPI sgx_fimport_auto_key(const char* filename, const sgx_key_128bit_t
 */
 int32_t SGXAPI sgx_fclear_cache(SGX_FILE* stream);
 
-/*
-*
-*
-*/
+
 #define SGX_AESGCM_MAC_SIZE             16
 typedef uint8_t aead_128bit_tag_t[SGX_AESGCM_MAC_SIZE];
 typedef aead_128bit_tag_t sgx_aes_gcm_128bit_tag_t;
+
+
+/* sgx_get_current_meta_gmac
+* Purpose: 
+*
+* Parameters:
+*     stream - [IN] the file handle
+*     out_gmac - [OUT] the current meta_data_gmac of the file
+*
+* Return value: 
+*     int32_t  - result, 0 - success, 1 - there was an error, check sgx_ferror for error code
+*/
 int32_t SGXAPI sgx_get_current_meta_gmac(SGX_FILE* stream, sgx_aes_gcm_128bit_tag_t out_gmac);
+
+
+/* sgx_rename_meta
+* Purpose: 
+*
+* Parameters:
+*     stream - [IN] the file handle
+*     old_name - [IN] the existing file name
+*     new_name - [IN] the new name
+*
+* Return value: 
+*     int32_t  - result, 0 - success, 1 - there was an error, check sgx_ferror for error code
+*/
+int32_t SGXAPI sgx_rename_meta(SGX_FILE* stream, const char* old_name, const char* new_name);
 
 #ifdef __cplusplus
 }

--- a/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/file_other.cpp
+++ b/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/file_other.cpp
@@ -393,11 +393,48 @@ int32_t protected_fs_file::clear_cache()
 
 int32_t protected_fs_file::get_current_meta_gmac(sgx_aes_gcm_128bit_tag_t out_gmac) {
 	if (out_gmac == NULL) {
-		return 1;
+		last_error = EINVAL;
+		return -1;
 	}
 
 	sgx_thread_mutex_lock(&mutex);
 	memcpy(out_gmac, file_meta_data.plain_part.meta_data_gmac, sizeof(sgx_aes_gcm_128bit_tag_t));
 	sgx_thread_mutex_unlock(&mutex);
+	return 0;
+}
+
+
+int32_t protected_fs_file::rename_meta(const char* old_name, const char* new_name) {
+	if ((old_name == NULL) || (new_name == NULL)) {
+		last_error = EINVAL;
+		return -1;
+	}
+
+	if (strnlen(old_name, FILENAME_MAX_LEN) >= FILENAME_MAX_LEN-1)
+	{
+		last_error = ENAMETOOLONG;
+		return -1;
+	}
+
+	if (strnlen(new_name, FILENAME_MAX_LEN) >= FILENAME_MAX_LEN-1)
+	{
+		last_error = ENAMETOOLONG;
+		return -1;
+	}
+
+	if (strncmp(old_name, encrypted_part_plain.clean_filename, FILENAME_MAX_LEN) != 0)
+	{
+		last_error = SGX_ERROR_FILE_NAME_MISMATCH;
+		return -1;
+	}
+
+	strncpy(encrypted_part_plain.clean_filename, new_name, FILENAME_MAX_LEN);
+
+	need_writing = true;
+	bool success = internal_flush(true);
+	if (success == false) {
+		last_error = SGX_ERROR_FILE_FLUSH_FAILED;
+		return -1;
+	}
 	return 0;
 }

--- a/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/protected_fs_file.h
+++ b/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/protected_fs_file.h
@@ -232,6 +232,7 @@ public:
 
 	// Add for MesaTEE
 	int32_t get_current_meta_gmac(sgx_aes_gcm_128bit_tag_t out_gmac);
+	int32_t rename_meta(const char* old_name, const char* new_name);
 };
 
 #pragma pack(pop)

--- a/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/sgx_tprotected_fs.cpp
+++ b/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/sgx_tprotected_fs.cpp
@@ -241,8 +241,20 @@ int32_t sgx_fclear_cache(SGX_FILE* stream)
 int32_t sgx_get_current_meta_gmac(SGX_FILE* stream, sgx_aes_gcm_128bit_tag_t out_gmac)
 {
 	if (stream == NULL)
-		return 1;
+		return -1;
+
 	protected_fs_file* file = (protected_fs_file*)stream;
+
 	return file->get_current_meta_gmac(out_gmac);
+}
+
+int32_t sgx_rename_meta(SGX_FILE* stream, const char* old_name, const char* new_name)
+{
+	if (stream == NULL)
+		return -1;
+
+	protected_fs_file* file = (protected_fs_file*)stream;
+
+	return file->rename_meta(old_name, new_name);
 }
 

--- a/mesatee_utils/protected_fs_rs/src/sgx_fs_inner.rs
+++ b/mesatee_utils/protected_fs_rs/src/sgx_fs_inner.rs
@@ -167,6 +167,14 @@ impl SgxFile {
             .get_current_meta_gmac(meta_gmac)
             .map_err(Error::from_raw_os_error)
     }
+
+    pub fn rename_meta(&self, old_name: &Path, new_name: &Path) -> io::Result<()> {
+        let old = cstr(old_name)?;
+        let new = cstr(new_name)?;
+        self.0
+            .rename_meta(&old, &new)
+            .map_err(Error::from_raw_os_error)
+    }
 }
 
 pub fn remove(path: &Path) -> io::Result<()> {

--- a/mesatee_utils/protected_fs_rs/tests/rename.rs
+++ b/mesatee_utils/protected_fs_rs/tests/rename.rs
@@ -1,0 +1,75 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+extern crate protected_fs;
+use protected_fs::{remove_protected_file, ProtectedFile};
+use rand_core::RngCore;
+use std::fs;
+use std::io::{Read, Write};
+
+#[test]
+fn test_rename() {
+    const BLOCK_SIZE: usize = 2048;
+
+    let key = [90u8; 16];
+    let mut auth_tag = [0u8; 16];
+
+    let mut write_data = [0u8; BLOCK_SIZE];
+    let mut read_data = [0u8; BLOCK_SIZE];
+
+    let mut rng = rdrand::RdRand::new().unwrap();
+    rng.fill_bytes(&mut write_data);
+
+    let old_name = "old_file";
+    let new_name = "new_file";
+
+    {
+        // create and write old_file
+        let mut file = ProtectedFile::create_ex(&old_name, &key).unwrap();
+        let write_size = file.write(&write_data).unwrap();
+        assert_eq!(write_size, write_data.len());
+    }
+
+    {
+        // rename_meta requires append mode
+        let mut file = ProtectedFile::append_ex(&old_name, &key).unwrap();
+        // rename_meta in protected file
+        file.rename_meta(&old_name, &new_name).unwrap();
+
+        // flush before we get the final auth_tag
+        file.flush().unwrap();
+
+        // get the latest gmac
+        file.get_current_meta_gmac(&mut auth_tag).unwrap();
+    }
+
+    // rename file after close
+    fs::rename(old_name, new_name).unwrap();
+
+    {
+        let mut auth_tag_in_file = [0xffu8; 16];
+        let mut file = ProtectedFile::open_ex(&new_name, &key).unwrap();
+
+        file.get_current_meta_gmac(&mut auth_tag_in_file).unwrap();
+        assert_eq!(auth_tag_in_file, auth_tag);
+
+        let read_size = file.read(&mut read_data).unwrap();
+        assert_eq!(read_size, read_data.len());
+
+        assert_eq!(&read_data[..], &write_data[..]);
+    }
+    assert_eq!(remove_protected_file(&new_name).is_ok(), true);
+}


### PR DESCRIPTION
## Description
When porting `rusty-leveldb` to MesaTEE, I found that the following features are missing for ProtectedFile. 
- Renaming file name in file meta.
- `read_at` function from random read.
This PR adds these two features. Later I will submit an another PR for leveldb-sgx library. 

Fixes # (issue)

## Type of change (select applied and DELETE the others)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just sync with upstream third-party crates

## How Has This Been Tested?
https://ci.mesalock-linux.org/m4sterchain/incubator-mesatee/37

## Checklist (check ALL before submitting PR, even not applicable)

- [x] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
